### PR TITLE
케어기버 및 아기 관련 도메인 모델과 페치 프로토콜 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ buildServer.json
 
 # Claude
 .claude/
+.agents/
 CLAUDE.md
 
 # VSCode

--- a/.swiftformat
+++ b/.swiftformat
@@ -101,6 +101,8 @@
 --disable fileHeader
 # markTypes 자동 삽입 비활성화 (markExtensions만 사용)
 --disable markTypes
+# 임포트 그룹 사이 빈 줄 허용
+--disable blankLinesBetweenImports
 
 # ============================
 # Exclude

--- a/Domain/Sources/Errors/CaregiverError.swift
+++ b/Domain/Sources/Errors/CaregiverError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// 보호자 및 아기 관련 작업 중 발생할 수 있는 오류를 정의합니다.
+public enum CaregiverError: Error, Sendable {
+    /// 해당 정보를 찾을 수 없음
+    case notFound
+    /// 권한 없음
+    case unauthorized
+    /// 이미 등록된 정보
+    case alreadyExists
+    /// 잘못된 상호작용 (예: 자기 자신을 연결 등)
+    case invalidInteraction
+    /// 네트워크 또는 데이터베이스 내부 오류
+    case internalError(Error?)
+
+    public var localizedDescription: String {
+        switch self {
+        case .notFound: "정보를 찾을 수 없습니다."
+        case .unauthorized: "권한이 없습니다."
+        case .alreadyExists: "이미 등록된 정보입니다."
+        case .invalidInteraction: "잘못된 요청입니다."
+        case let .internalError(error): "내부 오류가 발생했습니다: \(error?.localizedDescription ?? "알 수 없음")"
+        }
+    }
+}

--- a/Domain/Sources/Models/Baby.swift
+++ b/Domain/Sources/Models/Baby.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// 아기(Baby) 정보를 정의하는 도메인 모델입니다.
+public struct Baby: Sendable, Identifiable {
+    public let id: String
+    public var name: String
+    public var birthDate: Date
+    public var gender: Gender
+    public var bloodType: BloodType?
+    public var imageURL: URL?
+
+    public init(
+        id: String,
+        name: String,
+        birthDate: Date,
+        gender: Gender,
+        bloodType: BloodType? = nil,
+        imageURL: URL? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.birthDate = birthDate
+        self.gender = gender
+        self.bloodType = bloodType
+        self.imageURL = imageURL
+    }
+}

--- a/Domain/Sources/Models/BloodType.swift
+++ b/Domain/Sources/Models/BloodType.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// 아기의 혈액형을 나타내는 모델입니다.
+public enum BloodType: String, Sendable, Codable {
+    case A
+    case B
+    case O
+    case AB
+}

--- a/Domain/Sources/Models/Caregiver.swift
+++ b/Domain/Sources/Models/Caregiver.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// 보호자(Caregiver) 역할을 정의하는 도메인 모델입니다.
+/// 시스템 사용자인 `User`가 특정 가족/아기 그룹 내에서 가지는 역할을 나타냅니다.
+public struct Caregiver: Sendable, Identifiable {
+    public let id: String
+    public let name: String
+    public let email: String
+    public var role: String? // 예: 엄마, 아빠, 할머니 등 (자유 입력 또는 확장 가능)
+    public var lastSelectedBabyID: String?
+
+    public init(
+        id: String,
+        name: String,
+        email: String,
+        role: String? = nil,
+        lastSelectedBabyID: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.role = role
+        self.lastSelectedBabyID = lastSelectedBabyID
+    }
+}

--- a/Domain/Sources/Models/Gender.swift
+++ b/Domain/Sources/Models/Gender.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// 아기의 성별을 나타내는 모델입니다.
+public enum Gender: Int, Sendable, Codable {
+    case male = 1
+    case female = 2
+    case unknown = 0
+}

--- a/Domain/Sources/Protocols/CaregiverClient/BabyFetchable.swift
+++ b/Domain/Sources/Protocols/CaregiverClient/BabyFetchable.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// 아기 정보를 조회할 수 있는 능력을 정의하는 프로토콜입니다.
+public protocol BabyFetchable: Sendable {
+    /// 현재 보호자에게 연결된 모든 아기 목록을 조회합니다.
+    func fetchBabies() async throws(CaregiverError) -> [Baby]
+
+    /// 특정 ID의 아기 정보를 조회합니다.
+    func fetchBaby(id: String) async throws(CaregiverError) -> Baby
+}

--- a/Domain/Sources/Protocols/CaregiverClient/BabyRegisterable.swift
+++ b/Domain/Sources/Protocols/CaregiverClient/BabyRegisterable.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// 아기 정보를 등록하거나 수정할 수 있는 능력을 정의하는 프로토콜입니다.
+public protocol BabyRegisterable: Sendable {
+    /// 새로운 아기 정보를 등록합니다. 생성된 아기를 반환합니다.
+    func registerBaby(_ baby: Baby) async throws(CaregiverError) -> Baby
+
+    /// 기존 아기 정보를 업데이트합니다.
+    func updateBaby(_ baby: Baby) async throws(CaregiverError)
+
+    /// 아기 정보를 삭제합니다.
+    func deleteBaby(id: String) async throws(CaregiverError)
+}

--- a/Domain/Sources/Protocols/CaregiverClient/CaregiverConnectable.swift
+++ b/Domain/Sources/Protocols/CaregiverClient/CaregiverConnectable.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// 보호자 간의 연결(가족 초대/수락 등)을 관리하는 능력을 정의하는 프로토콜입니다.
+public protocol CaregiverConnectable: Sendable {
+    /// 다른 보호자를 가족으로 초대합니다.
+    func inviteCaregiver(email: String) async throws(CaregiverError)
+
+    /// 가족 초대 요청을 수락하거나 거절합니다.
+    func respondToInvitation(invitationID: String, accept: Bool) async throws(CaregiverError)
+
+    /// 가족 연결을 해제합니다.
+    func disconnectCaregiver(id: String) async throws(CaregiverError)
+}

--- a/Domain/Sources/Protocols/CaregiverClient/CaregiverFetchable.swift
+++ b/Domain/Sources/Protocols/CaregiverClient/CaregiverFetchable.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// 보호자 정보를 조회할 수 있는 능력을 정의하는 프로토콜입니다.
+public protocol CaregiverFetchable: Sendable {
+    /// 특정 ID의 보호자 정보를 조회합니다.
+    func fetchCaregiver(id: String) async throws(CaregiverError) -> Caregiver
+
+    /// 현재 가족 그룹에 속한 모든 보호자 목록을 조회합니다.
+    func fetchFamilyCaregivers() async throws(CaregiverError) -> [Caregiver]
+}

--- a/Domain/Sources/Protocols/CaregiverClient/CaregiverRegisterable.swift
+++ b/Domain/Sources/Protocols/CaregiverClient/CaregiverRegisterable.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// 보호자 정보를 등록하거나 수정할 수 있는 능력을 정의하는 프로토콜입니다.
+public protocol CaregiverRegisterable: Sendable {
+    /// 보호자 프로필 정보를 등록하거나 업데이트합니다.
+    func updateCaregiver(_ caregiver: Caregiver) async throws(CaregiverError)
+}

--- a/Domain/Tests/AuthErrorTests.swift
+++ b/Domain/Tests/AuthErrorTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Domain
 
 final class AuthErrorTests: XCTestCase {

--- a/Domain/Tests/BabyTests.swift
+++ b/Domain/Tests/BabyTests.swift
@@ -2,8 +2,11 @@ import XCTest
 @testable import Domain
 
 final class BabyTests: XCTestCase {
-    func test_init_setsPropertiesCorrectly() {
+    func test_Given_아기정보가있을때_When_초기화하면_Then_모든데이터가정상적으로설정됨() {
+        // Given
         let birthDate = Date()
+
+        // When
         let baby = Baby(
             id: "baby-1",
             name: "햇님이",
@@ -13,6 +16,7 @@ final class BabyTests: XCTestCase {
             imageURL: URL(string: "https://example.com/baby.jpg")
         )
 
+        // Then
         XCTAssertEqual(baby.id, "baby-1")
         XCTAssertEqual(baby.name, "햇님이")
         XCTAssertEqual(baby.birthDate, birthDate)
@@ -21,8 +25,11 @@ final class BabyTests: XCTestCase {
         XCTAssertEqual(baby.imageURL?.absoluteString, "https://example.com/baby.jpg")
     }
 
-    func test_init_withOptionalProperties_setsNilCorrectly() {
+    func test_Given_혈액형이미지가없을때_When_초기화하면_Then_해당필드가nil로설정됨() {
+        // Given
         let birthDate = Date()
+
+        // When
         let baby = Baby(
             id: "baby-2",
             name: "달님이",
@@ -30,6 +37,7 @@ final class BabyTests: XCTestCase {
             gender: .female
         )
 
+        // Then
         XCTAssertNil(baby.bloodType)
         XCTAssertNil(baby.imageURL)
     }

--- a/Domain/Tests/BabyTests.swift
+++ b/Domain/Tests/BabyTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Domain
 
 final class BabyTests: XCTestCase {

--- a/Domain/Tests/BabyTests.swift
+++ b/Domain/Tests/BabyTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Domain
+
+final class BabyTests: XCTestCase {
+    func test_init_setsPropertiesCorrectly() {
+        let birthDate = Date()
+        let baby = Baby(
+            id: "baby-1",
+            name: "햇님이",
+            birthDate: birthDate,
+            gender: .male,
+            bloodType: .A,
+            imageURL: URL(string: "https://example.com/baby.jpg")
+        )
+
+        XCTAssertEqual(baby.id, "baby-1")
+        XCTAssertEqual(baby.name, "햇님이")
+        XCTAssertEqual(baby.birthDate, birthDate)
+        XCTAssertEqual(baby.gender, .male)
+        XCTAssertEqual(baby.bloodType, .A)
+        XCTAssertEqual(baby.imageURL?.absoluteString, "https://example.com/baby.jpg")
+    }
+
+    func test_init_withOptionalProperties_setsNilCorrectly() {
+        let birthDate = Date()
+        let baby = Baby(
+            id: "baby-2",
+            name: "달님이",
+            birthDate: birthDate,
+            gender: .female
+        )
+
+        XCTAssertNil(baby.bloodType)
+        XCTAssertNil(baby.imageURL)
+    }
+}

--- a/Domain/Tests/CaregiverErrorTests.swift
+++ b/Domain/Tests/CaregiverErrorTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Domain
+
+final class CaregiverErrorTests: XCTestCase {
+    func test_errorDescription_returnsCorrectMessage_forEachCase() {
+        XCTAssertEqual(CaregiverError.notFound.localizedDescription, "정보를 찾을 수 없습니다.")
+        XCTAssertEqual(CaregiverError.unauthorized.localizedDescription, "권한이 없습니다.")
+        XCTAssertEqual(CaregiverError.alreadyExists.localizedDescription, "이미 등록된 정보입니다.")
+        XCTAssertEqual(CaregiverError.invalidInteraction.localizedDescription, "잘못된 요청입니다.")
+
+        let underlyingError = NSError(
+            domain: "test",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "테스트 에러"]
+        )
+        XCTAssertTrue(CaregiverError.internalError(underlyingError).localizedDescription
+            .contains("테스트 에러"))
+    }
+}

--- a/Domain/Tests/CaregiverErrorTests.swift
+++ b/Domain/Tests/CaregiverErrorTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Domain
 
 final class CaregiverErrorTests: XCTestCase {

--- a/Domain/Tests/CaregiverErrorTests.swift
+++ b/Domain/Tests/CaregiverErrorTests.swift
@@ -2,18 +2,24 @@ import XCTest
 @testable import Domain
 
 final class CaregiverErrorTests: XCTestCase {
-    func test_errorDescription_returnsCorrectMessage_forEachCase() {
+    func test_Given_케어기버에러가발생했을때_When_메시지를조회하면_Then_정의된한국어메시지가반환됨() {
+        // Given & When & Then
         XCTAssertEqual(CaregiverError.notFound.localizedDescription, "정보를 찾을 수 없습니다.")
         XCTAssertEqual(CaregiverError.unauthorized.localizedDescription, "권한이 없습니다.")
         XCTAssertEqual(CaregiverError.alreadyExists.localizedDescription, "이미 등록된 정보입니다.")
         XCTAssertEqual(CaregiverError.invalidInteraction.localizedDescription, "잘못된 요청입니다.")
 
+        // Given
         let underlyingError = NSError(
             domain: "test",
             code: 1,
             userInfo: [NSLocalizedDescriptionKey: "테스트 에러"]
         )
-        XCTAssertTrue(CaregiverError.internalError(underlyingError).localizedDescription
-            .contains("테스트 에러"))
+
+        // When
+        let error = CaregiverError.internalError(underlyingError)
+
+        // Then
+        XCTAssertTrue(error.localizedDescription.contains("테스트 에러"))
     }
 }

--- a/Domain/Tests/CaregiverTests.swift
+++ b/Domain/Tests/CaregiverTests.swift
@@ -2,7 +2,8 @@ import XCTest
 @testable import Domain
 
 final class CaregiverTests: XCTestCase {
-    func test_init_setsPropertiesCorrectly() {
+    func test_Given_보호자정보가있을때_When_초기화하면_Then_모든데이터가정상적으로설정됨() {
+        // Given & When
         let caregiver = Caregiver(
             id: "caregiver-1",
             name: "보호자",
@@ -11,6 +12,7 @@ final class CaregiverTests: XCTestCase {
             lastSelectedBabyID: "baby-1"
         )
 
+        // Then
         XCTAssertEqual(caregiver.id, "caregiver-1")
         XCTAssertEqual(caregiver.name, "보호자")
         XCTAssertEqual(caregiver.email, "parent@example.com")
@@ -18,13 +20,15 @@ final class CaregiverTests: XCTestCase {
         XCTAssertEqual(caregiver.lastSelectedBabyID, "baby-1")
     }
 
-    func test_init_withOptionalProperties_setsNilCorrectly() {
+    func test_Given_선택적데이터가없을때_When_초기화하면_Then_해당필드가nil로설정됨() {
+        // Given & When
         let caregiver = Caregiver(
             id: "caregiver-2",
             name: "아빠",
             email: "father@example.com"
         )
 
+        // Then
         XCTAssertNil(caregiver.role)
         XCTAssertNil(caregiver.lastSelectedBabyID)
     }

--- a/Domain/Tests/CaregiverTests.swift
+++ b/Domain/Tests/CaregiverTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Domain
+
+final class CaregiverTests: XCTestCase {
+    func test_init_setsPropertiesCorrectly() {
+        let caregiver = Caregiver(
+            id: "caregiver-1",
+            name: "보호자",
+            email: "parent@example.com",
+            role: "엄마",
+            lastSelectedBabyID: "baby-1"
+        )
+
+        XCTAssertEqual(caregiver.id, "caregiver-1")
+        XCTAssertEqual(caregiver.name, "보호자")
+        XCTAssertEqual(caregiver.email, "parent@example.com")
+        XCTAssertEqual(caregiver.role, "엄마")
+        XCTAssertEqual(caregiver.lastSelectedBabyID, "baby-1")
+    }
+
+    func test_init_withOptionalProperties_setsNilCorrectly() {
+        let caregiver = Caregiver(
+            id: "caregiver-2",
+            name: "아빠",
+            email: "father@example.com"
+        )
+
+        XCTAssertNil(caregiver.role)
+        XCTAssertNil(caregiver.lastSelectedBabyID)
+    }
+}

--- a/Domain/Tests/CaregiverTests.swift
+++ b/Domain/Tests/CaregiverTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Domain
 
 final class CaregiverTests: XCTestCase {

--- a/Domain/Tests/LoginProviderTests.swift
+++ b/Domain/Tests/LoginProviderTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Domain
 
 final class LoginProviderTests: XCTestCase {

--- a/Domain/Tests/UserTests.swift
+++ b/Domain/Tests/UserTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Domain
 
 final class UserTests: XCTestCase {


### PR DESCRIPTION
## 📌 연결 이슈

Closes #170

---

## 📝 변경 사항 요약

`Domain` 레이어에 육아 관리를 위한 핵심 도메인 모델(`Caregiver`, `Baby`)과 관련 인터페이스(Fetch, Register, Connect)를 추가하고, 이에 대한 단위 테스트를 구축했습니다.

### 변경 내용

- **도메인 모델 추가**: `Caregiver`, `Baby`, `Gender`, `BloodType` 등 순수 스위프트 모델 정의
- **프로토콜 정의**:
  - `CaregiverFetchable`, `BabyFetchable`: 정보 조회 인터페이스
  - `CaregiverRegisterable`, `BabyRegisterable`: 정보 등록 인터페이스
  - `CaregiverConnectable`: 케어기버 간 연결 인터페이스
- **테스트 강화**:
  - `CaregiverTests`, `BabyTests`, `CaregiverErrorTests` 작성
  - 모든 테스트에 `Given-When-Then` 구조 및 한국어 메서드 명명법 적용
- **코드 스타일**:
  - `.swiftformat` 수정을 통해 `import XCTest`와 `@testable import Domain` 사이의 빈 줄 허용 및 적용

### 영향 범위

| 구분 | 내용 |
|------|------|
| 모듈 | `Domain` |
| 화면/기능 | 도메인 모델 및 데이터 통신 인터페이스(프로토콜) |

---

## 🧪 검증

- [x] Xcode에서 `Domain` 타겟 빌드 성공
- [x] `DomainTests` 유닛 테스트 전원 통과
- [x] `SwiftFormat` 린트 체크 완료

---

## 📸 스크린샷 (UI 변경 없음)

N/A
