### PR TITLE
feat: CaregiverClient Firestore 실구현 및 통합 테스트 추가

### DIFF
--- a/Core/Project.swift
+++ b/Core/Project.swift
@@ -15,7 +15,8 @@ let project = Project(
             scripts: [.swiftFormat],
             dependencies: [
                 .project(target: "Domain", path: "../Domain"),
-                .external(name: "FirebaseAuth")
+                .external(name: "FirebaseAuth"),
+                .external(name: "FirebaseFirestore")
             ]
         ),
         .target(
@@ -28,7 +29,8 @@ let project = Project(
             sources: ["Tests/**/*.swift"],
             dependencies: [
                     .target(name: "Core"),
-                    .external(name: "FirebaseCore")
+                    .external(name: "FirebaseCore"),
+                    .external(name: "FirebaseFirestore")
                 ]
         )
     ],

--- a/Core/Sources/Clients/CaregiverClient+Live.swift
+++ b/Core/Sources/Clients/CaregiverClient+Live.swift
@@ -1,0 +1,55 @@
+import Domain
+import FirebaseFirestore
+import Foundation
+
+extension CaregiverClient {
+    public static var liveValue: Self {
+        let db = Firestore.firestore()
+
+        return Self(
+            fetchCaregiver: { uid in
+                let snapshot = try await db.collection("users").document(uid).getDocument()
+                guard let data = snapshot.data() else {
+                    throw CaregiverError.notFound
+                }
+
+                return Caregiver(
+                    id: uid,
+                    name: data["name"] as? String ?? "",
+                    email: data["email"] as? String ?? "",
+                    role: data["role"] as? String,
+                    lastSelectedBabyID: data["lastSelectedBabyId"] as? String
+                )
+            },
+            registerCaregiver: { caregiver in
+                let data: [String: Any] = [
+                    "id": caregiver.id,
+                    "name": caregiver.name,
+                    "email": caregiver.email,
+                    "role": caregiver.role as Any,
+                    "lastSelectedBabyId": caregiver.lastSelectedBabyID as Any,
+                    "babies": [] // 초기 가입 시 빈 배열
+                ]
+                try await db.collection("users").document(caregiver.id).setData(data)
+            },
+            connectCaregiver: { caregiverID, babyID in
+                let userRef = db.collection("users").document(caregiverID)
+                let babyRef = db.collection("babies").document(babyID)
+
+                try await db.runTransaction { transaction, _ in
+                    // 1. 사용자 문서에 아기 참조 추가
+                    transaction.updateData([
+                        "babies": FieldValue.arrayUnion([babyRef])
+                    ], forDocument: userRef)
+
+                    // 2. 아기 문서에 보호자 참조 추가
+                    transaction.updateData([
+                        "caregivers": FieldValue.arrayUnion([userRef])
+                    ], forDocument: babyRef)
+
+                    return nil
+                }
+            }
+        )
+    }
+}

--- a/Core/Tests/Clients/CaregiverClientLiveTests.swift
+++ b/Core/Tests/Clients/CaregiverClientLiveTests.swift
@@ -1,0 +1,97 @@
+import Domain
+import FirebaseCore
+import FirebaseFirestore
+import XCTest
+@testable import Core
+
+final class CaregiverClientLiveTests: XCTestCase {
+    var db: Firestore!
+    var client: CaregiverClient!
+
+    override class func setUp() {
+        super.setUp()
+        if FirebaseApp.app() == nil {
+            let options = FirebaseOptions(
+                googleAppID: "1:1234567890:ios:321abc456def7890",
+                gcmSenderID: "1234567890"
+            )
+            options.projectID = "demo-myiapp"
+            options.apiKey = "AIzaSyDummyKey123456789"
+            FirebaseApp.configure(options: options)
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+        self.db = Firestore.firestore()
+        let settings = self.db.settings
+        settings.host = "127.0.0.1:8080"
+        settings.isPersistenceEnabled = false
+        settings.isSSLEnabled = false
+        self.db.settings = settings
+
+        self.client = CaregiverClient.liveValue
+    }
+
+    func test_Given_보호자정보_When_registerCaregiver호출시_Then_성공적으로저장됨() async throws {
+        // Given
+        let caregiver = Caregiver(
+            id: UUID().uuidString,
+            name: "테스트 보호자",
+            email: "test@example.com",
+            role: "엄마"
+        )
+
+        // When
+        try await self.client.registerCaregiver(caregiver)
+
+        // Then
+        let fetched = try await client.fetchCaregiver(caregiver.id)
+        XCTAssertEqual(fetched.id, caregiver.id)
+        XCTAssertEqual(fetched.name, caregiver.name)
+        XCTAssertEqual(fetched.role, caregiver.role)
+    }
+
+    func test_Given_존재하지않는ID_When_fetchCaregiver호출시_Then_notFound에러반환() async throws {
+        // Given
+        let invalidID = "invalid_id"
+
+        // When / Then
+        do {
+            _ = try await self.client.fetchCaregiver(invalidID)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch let error as CaregiverError {
+            XCTAssertEqual(error, .notFound)
+        } catch {
+            XCTFail("CaregiverError.notFound가 발생해야 합니다: \(error)")
+        }
+    }
+
+    func test_Given_사용자와아기_When_connectCaregiver호출시_Then_상호연결됨() async throws {
+        // Given
+        let caregiverID = UUID().uuidString
+        let babyID = UUID().uuidString
+
+        let caregiver = Caregiver(id: caregiverID, name: "보호자", email: "p@e.com")
+        try await client.registerCaregiver(caregiver)
+
+        // 아기 문서는 명시적으로 먼저 생성 (legacy 방식 대비 간소화)
+        try await self.db.collection("babies").document(babyID).setData([
+            "id": babyID,
+            "name": "아기",
+            "caregivers": []
+        ])
+
+        // When
+        try await self.client.connectCaregiver(caregiverID, babyID)
+
+        // Then
+        let userDoc = try await db.collection("users").document(caregiverID).getDocument()
+        let babyRefs = userDoc.data()?["babies"] as? [DocumentReference]
+        XCTAssertTrue(babyRefs?.contains(where: { $0.documentID == babyID }) ?? false)
+
+        let babyDoc = try await db.collection("babies").document(babyID).getDocument()
+        let caregiverRefs = babyDoc.data()?["caregivers"] as? [DocumentReference]
+        XCTAssertTrue(caregiverRefs?.contains(where: { $0.documentID == caregiverID }) ?? false)
+    }
+}

--- a/Domain/Sources/Errors/CaregiverError.swift
+++ b/Domain/Sources/Errors/CaregiverError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// 보호자 및 아기 관련 작업 중 발생할 수 있는 오류를 정의합니다.
-public enum CaregiverError: Error, Sendable {
+public enum CaregiverError: Error, Equatable, Sendable {
     /// 해당 정보를 찾을 수 없음
     case notFound
     /// 권한 없음
@@ -20,6 +20,20 @@ public enum CaregiverError: Error, Sendable {
         case .alreadyExists: "이미 등록된 정보입니다."
         case .invalidInteraction: "잘못된 요청입니다."
         case let .internalError(error): "내부 오류가 발생했습니다: \(error?.localizedDescription ?? "알 수 없음")"
+        }
+    }
+
+    public static func == (lhs: CaregiverError, rhs: CaregiverError) -> Bool {
+        switch (lhs, rhs) {
+        case (.notFound, .notFound),
+             (.unauthorized, .unauthorized),
+             (.alreadyExists, .alreadyExists),
+             (.invalidInteraction, .invalidInteraction):
+            true
+        case (.internalError, .internalError):
+            true // 내부 오류는 발생 여부만 비교
+        default:
+            false
         }
     }
 }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -7,8 +7,7 @@ import PackageDescription
     let packageSettings = PackageSettings(
         productTypes: [
             "FirebaseAuth": .framework,
-            "FirebaseCore": .framework,
-            "FirebaseFirestore": .framework
+            "FirebaseCore": .framework
         ]
     )
 #endif


### PR DESCRIPTION
## 📌 연결 이슈

Closes #174

---

## 📝 변경 사항 요약

CaregiverClient의 Firestore 기반 실구현 및 관련 테스트/환경 설정을 추가했습니다.

### 변경 내용

- `Core`: `CaregiverClient.liveValue` 구현 및 Firestore 연동
- `CoreTests`: `CaregiverClientLiveTests` 통합 테스트 추가
- `Domain`: `CaregiverError`에 `Equatable` 채택 및 구현
- `Tuist`: Firestore 링킹 이슈 해결을 위한 `Package.swift` 수정
- `Firebase`: `firebase.json`에 `firestore` 에뮬레이터 설정 추가

### 영향 범위

| 구분 | 내용 |
|------|------|
| 모듈 | Core, Domain, Tuist |
| 화면/기능 | 보호자 데이터 연동 및 관리 |

---

## 🧪 검증

- [x] `tuist generate` 성공 (Tuist 프로젝트인 경우)
- [x] Xcode에서 빌드 성공
- [x] 시뮬레이터/실기기 동작 확인
- [x] (필요 시) 린트/테스트 통과

---

## 📸 스크린샷 (UI 변경 시)

(N/A)
