### PR TITLE
feat: RecordClient Firestore 실구현 및 통합 테스트 추가

### DIFF
--- a/Core/Sources/Clients/RecordClient+Live.swift
+++ b/Core/Sources/Clients/RecordClient+Live.swift
@@ -1,0 +1,50 @@
+import Domain
+import FirebaseFirestore
+import Foundation
+
+extension RecordClient {
+    public static var liveValue: Self {
+        let db = Firestore.firestore()
+
+        return Self(
+            fetchRecords: { babyID in
+                let snapshot = try await db.collection("records")
+                    .whereField("babyID", isEqualTo: babyID)
+                    .order(by: "timestamp", descending: true)
+                    .getDocuments()
+
+                return snapshot.documents.compactMap { doc in
+                    let data = doc.data()
+                    guard let typeString = data["type"] as? String,
+                          let type = RecordType(rawValue: typeString),
+                          let timestamp = (data["timestamp"] as? Timestamp)?.dateValue()
+                    else {
+                        return nil
+                    }
+
+                    return Record(
+                        id: doc.documentID,
+                        babyID: babyID,
+                        type: type,
+                        timestamp: timestamp,
+                        note: data["note"] as? String,
+                        metadata: data["metadata"] as? [String: String]
+                    )
+                }
+            },
+            saveRecord: { record in
+                let data: [String: Any] = [
+                    "babyID": record.babyID,
+                    "type": record.type.rawValue,
+                    "timestamp": Timestamp(date: record.timestamp),
+                    "note": record.note as Any,
+                    "metadata": record.metadata as Any
+                ]
+                try await db.collection("records").document(record.id).setData(data)
+            },
+            deleteRecord: { id in
+                try await db.collection("records").document(id).delete()
+            }
+        )
+    }
+}

--- a/Core/Tests/Clients/RecordClientLiveTests.swift
+++ b/Core/Tests/Clients/RecordClientLiveTests.swift
@@ -1,0 +1,94 @@
+import Domain
+import FirebaseCore
+import FirebaseFirestore
+import XCTest
+@testable import Core
+
+final class RecordClientLiveTests: XCTestCase {
+    var db: Firestore!
+    var client: RecordClient!
+
+    override class func setUp() {
+        super.setUp()
+        if FirebaseApp.app() == nil {
+            let options = FirebaseOptions(
+                googleAppID: "1:1234567890:ios:321abc456def7890",
+                gcmSenderID: "1234567890"
+            )
+            options.projectID = "demo-myiapp"
+            options.apiKey = "AIzaSyDummyKey123456789"
+            FirebaseApp.configure(options: options)
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+        self.db = Firestore.firestore()
+        let settings = self.db.settings
+        settings.host = "127.0.0.1:8080"
+        settings.isPersistenceEnabled = false
+        settings.isSSLEnabled = false
+        self.db.settings = settings
+
+        self.client = RecordClient.liveValue
+    }
+
+    func test_Given_기록정보_When_saveRecord호출시_Then_성공적으로저장됨() async throws {
+        // Given
+        let babyID = UUID().uuidString
+        let record = Record(
+            babyID: babyID,
+            type: .feeding,
+            timestamp: Date(),
+            note: "테스트 수유 기록",
+            metadata: ["amount": "120ml"]
+        )
+
+        // When
+        try await client.saveRecord(record)
+
+        // Then
+        let records = try await client.fetchRecords(babyID)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.first?.id, record.id)
+        XCTAssertEqual(records.first?.type, .feeding)
+        XCTAssertEqual(records.first?.metadata?["amount"], "120ml")
+    }
+
+    func test_Given_여러기록_When_fetchRecords호출시_Then_최신순으로정렬됨() async throws {
+        // Given
+        let babyID = UUID().uuidString
+        let now = Date()
+        let oldRecord = Record(
+            babyID: babyID,
+            type: .sleep,
+            timestamp: now.addingTimeInterval(-3600)
+        )
+        let newRecord = Record(babyID: babyID, type: .diaper, timestamp: now)
+
+        try await client.saveRecord(oldRecord)
+        try await self.client.saveRecord(newRecord)
+
+        // When
+        let records = try await client.fetchRecords(babyID)
+
+        // Then
+        XCTAssertEqual(records.count, 2)
+        XCTAssertEqual(records[0].id, newRecord.id)
+        XCTAssertEqual(records[1].id, oldRecord.id)
+    }
+
+    func test_Given_기존기록_When_deleteRecord호출시_Then_삭제됨() async throws {
+        // Given
+        let babyID = UUID().uuidString
+        let record = Record(babyID: babyID, type: .cry)
+        try await client.saveRecord(record)
+
+        // When
+        try await self.client.deleteRecord(record.id)
+
+        // Then
+        let records = try await client.fetchRecords(babyID)
+        XCTAssertTrue(records.isEmpty)
+    }
+}


### PR DESCRIPTION
## 📌 연결 이슈

Closes #175

---

## 📝 변경 사항 요약

RecordClient의 Firestore 기반 실구현 및 관련 테스트를 추가했습니다.

### 변경 내용

- `Core`: `RecordClient.liveValue` 구현 (Fetch, Save, Delete)
- `CoreTests`: `RecordClientLiveTests` 통합 테스트 추가

### 영향 범위

| 구분 | 내용 |
|------|------|
| 모듈 | Core, Domain |
| 화면/기능 | 아기 성장 기록 데이터 연동 및 관리 |

---

## 🧪 검증

- [x] `tuist generate` 성공 (Tuist 프로젝트인 경우)
- [x] Xcode에서 빌드 성공
- [x] 시뮬레이터/실기기 동작 확인
- [x] (필요 시) 린트/테스트 통과

---

## 📸 스크린샷 (UI 변경 시)

(N/A)
