### PR TITLE
Xcode Cloud 기반 CI/CD 파이프라인 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: SwiftFormat lint
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SwiftFormat
+        run: brew install swiftformat
+
+      - name: Run SwiftFormat (lint mode)
+        run: swiftformat --lint .

--- a/DesignSystem/Asset+Alias.swift
+++ b/DesignSystem/Asset+Alias.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 public typealias Asset = DesignSystemAsset
 
-public extension Image {
-    init(_ asset: DesignSystemImages) {
+extension Image {
+    public init(_ asset: DesignSystemImages) {
         self.init(asset: asset)
     }
 }
 
-public extension Color {
-    init(_ asset: DesignSystemColors) {
+extension Color {
+    public init(_ asset: DesignSystemColors) {
         self.init(asset: asset)
     }
 }

--- a/FeaturesTests/FeaturesTests.swift
+++ b/FeaturesTests/FeaturesTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import Features
+
+final class FeaturesTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertTrue(true)
+    }
+}

--- a/MyI/Tests/MyITests.swift
+++ b/MyI/Tests/MyITests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MyI
+
+final class MyITests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertTrue(true)
+    }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -126,6 +126,28 @@ let project = Project(
                     "TARGETED_DEVICE_FAMILY": "1"
                 ]
             )
+        ),
+        .target(
+            name: "FeaturesTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "kr.co.codegrove.FeaturesTests",
+            deploymentTargets: .iOS("17.0"),
+            sources: ["FeaturesTests/**/*.swift"],
+            dependencies: [
+                .target(name: "Features")
+            ]
+        ),
+        .target(
+            name: "MyITests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "kr.co.codegrove.MyITests",
+            deploymentTargets: .iOS("17.0"),
+            sources: ["MyI/Tests/**/*.swift"],
+            dependencies: [
+                .target(name: "MyI")
+            ]
         )
     ]
 )

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -3,12 +3,20 @@ set -eu
 
 # Xcode Cloud post-clone hook
 # Tuist 프로젝트라 xcodebuild 호출 전에 xcodeproj/xcworkspace 생성이 필요.
+# - GoogleService-Info.plist 복원 (Environment Variable에서)
 # - Tuist 설치
 # - SPM 의존성 fetch
 # - xcodeproj/xcworkspace 생성
 
 # Repo root로 이동 (ci_scripts/에서 한 단계 위)
 cd "$(dirname "$0")/.."
+
+# GoogleService-Info.plist 복원 (.gitignore라 repo에 없음)
+# Xcode Cloud Environment Variable `GOOGLE_SERVICE_INFO_PLIST_BASE64`에서 디코딩.
+# 로컬 빌드는 이미 plist 있으니 변수 없으면 skip.
+if [ -n "${GOOGLE_SERVICE_INFO_PLIST_BASE64:-}" ]; then
+  echo "$GOOGLE_SERVICE_INFO_PLIST_BASE64" | base64 --decode > MyI/Resources/GoogleService-Info.plist
+fi
 
 brew install tuist
 tuist install

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+# Xcode Cloud post-clone hook
+# Tuist 프로젝트라 xcodebuild 호출 전에 xcodeproj/xcworkspace 생성이 필요.
+# - Tuist 설치
+# - SPM 의존성 fetch
+# - xcodeproj/xcworkspace 생성
+
+# Repo root로 이동 (ci_scripts/에서 한 단계 위)
+cd "$(dirname "$0")/.."
+
+brew install tuist
+tuist install
+tuist generate --no-open


### PR DESCRIPTION
## 📝 개요

GitHub Actions로 PR 포매팅 검사를 자동화하고, Xcode Cloud로 `develop` → TestFlight 자동 배포 + `main` → App Store Connect 빌드 등록을 셋업한다.
App Store 출시는 웹에서 수동.

## 🔗 관련 이슈

- Closes #215

## 🛠️ 작업 내용

- placeholder 유닛 테스트 타겟 2개 추가 (`MyITests`, `FeaturesTests`)
- GitHub Actions `ci.yml` — SwiftFormat lint PR 검증
- Xcode Cloud `ci_post_clone.sh` — Tuist install + generate + `GoogleService-Info.plist` 복원

## 📖 설명

Tuist 산출물(`MyI.xcodeproj`/`MyI.xcworkspace`)이 `.gitignore`라 Xcode Cloud 클론 결과엔 없는데, `ci_post_clone.sh`가 클론 직후 자동 실행되어 `tuist install + tuist generate`로 xcworkspace를 만들고 `GOOGLE_SERVICE_INFO_PLIST_BASE64` 환경변수에서 plist를 복원한다. 
그 다음 xcodebuild가 Test → Archive를 수행하고, archive 결과가 업로드된다.

`develop`에 머지된 빌드는 TestFlight Internal Testing 그룹(`MyI_Internal`)의 Automatic Distribution으로 자동 노출된다. `main`에 머지된 빌드는 ASC App Store 빌드 슬롯에 등록되며, 매 출시 시 사용자가 ASC 웹에서 새 버전을 만들고 메타·스크린샷·release notes 작성 후 Submit/Release를 수동으로 진행한다.

## 🔄 플로우 다이어그램

```mermaid
flowchart TD
    PR[PR 열림] --> CI[GitHub Actions ci.yml]
    CI --> SF[SwiftFormat lint]

    DEV[develop 머지] --> WA[Xcode Cloud Workflow A]
    MAIN[main 머지] --> WB[Xcode Cloud Workflow B]

    WA --> CLN[ci_post_clone.sh<br/>tuist install + generate<br/>GoogleService-Info 복원]
    WB --> CLN

    CLN --> XB[xcodebuild: Test → Archive]

    XB -->|Workflow A 결과| TF[ASC TestFlight<br/>MyI_Internal 그룹 자동 노출]
    XB -->|Workflow B 결과| AS[ASC App Store<br/>빌드 슬롯 등록]

    AS --> USR[사용자 ASC 웹<br/>새 버전 + 메타 + 스크린샷<br/>+ Submit + Release]
```