### PR TITLE
Firebase Crashlytics를 도입합니다.

### DIFF
--- a/Clients/Bootstrap.swift
+++ b/Clients/Bootstrap.swift
@@ -1,6 +1,7 @@
 import Domain
 @preconcurrency import FirebaseAuth
 import FirebaseCore
+@preconcurrency import FirebaseCrashlytics
 @preconcurrency import FirebaseFirestore
 @preconcurrency import FirebaseMessaging
 import GoogleSignIn
@@ -13,12 +14,21 @@ public enum AppBootstrap {
     public static func configure() {
         FirebaseApp.configure()
 
+        #if DEBUG
+            Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+        #endif
+
         if let clientID = FirebaseApp.app()?.options.clientID {
             GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
         }
 
         Messaging.messaging().delegate = notificationCoordinator
         UNUserNotificationCenter.current().delegate = notificationCoordinator
+
+        Auth.auth().addStateDidChangeListener { _, user in
+            Crashlytics.crashlytics().setUserID(user?.uid ?? "")
+        }
+
         AppLogger.info("AppBootstrap configured")
     }
 

--- a/Project.swift
+++ b/Project.swift
@@ -49,6 +49,7 @@ let project = Project(
                 .external(name: "FirebaseFirestore"),
                 .external(name: "FirebaseStorage"),
                 .external(name: "FirebaseMessaging"),
+                .external(name: "FirebaseCrashlytics"),
                 .external(name: "GoogleSignIn"),
                 .external(name: "GoogleSignInSwift")
             ]
@@ -109,6 +110,18 @@ let project = Project(
                 "com.apple.developer.applesignin": .array(["Default"]),
                 "aps-environment": .string("production")
             ]),
+            scripts: [
+                .post(
+                    script: """
+                    "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+                    """,
+                    name: "Firebase Crashlytics dSYM Upload",
+                    inputPaths: [
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+                        "$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)"
+                    ]
+                )
+            ],
             dependencies: [
                 .target(name: "Domain"),
                 .target(name: "Clients"),


### PR DESCRIPTION
## 📝 개요

Firebase Crashlytics SDK를 추가하고 dSYM 자동 업로드 · Debug 빌드 수집 비활성화 · Firebase Auth uid 기반 사용자 식별을 연동합니다.

## 🔗 관련 이슈

- Refs #217

## 📖 설명

### 도입 스코프 — SDK + 사용자 식별까지만

SDK만 추가하면 어떤 사용자에서 터졌는지 모르고, 풀 통합(non-fatal 자동 기록)까지 가면 의미 있는 신호가 noise에 묻힙니다. `setUserID`까지가 비용 대비 효용이 가장 명확한 절단점이라 판단.

non-fatal 기록은 운영 데이터를 본 뒤 진짜 필요해질 때 별도 spec으로 추가합니다.

### dSYM 업로드 — Run Script Build Phase (D2)

firebase-ios-sdk SPM checkout 안의 `Crashlytics/run` 스크립트를 post-build script로 직접 호출합니다. 

### setUserID 위치 — AppBootstrap 별도 listener (D4)

`AuthClientLive.stateStream`에 끼워넣으면 Auth client에 Crashlytics 의존이 부풀어 도메인 client 책임이 흐려집니다. `AppBootstrap.configure()`에서 별도 `Auth.auth().addStateDidChangeListener`를 등록

## 🔄 플로우 다이어그램

```mermaid
sequenceDiagram
    participant App as AppDelegate
    participant Boot as AppBootstrap
    participant FB as FirebaseApp
    participant Auth as FirebaseAuth
    participant CL as Crashlytics

    App->>Boot: configure()
    Boot->>FB: FirebaseApp.configure()
    Note over CL: SDK 자동 시작
    alt DEBUG
        Boot->>CL: setCrashlyticsCollectionEnabled(false)
    end
    Boot->>Auth: addStateDidChangeListener
    Note over Auth: 로그인/로그아웃/세션 복원
    Auth-->>CL: setUserID(uid ?? "")

    Note over App, CL: ── 런타임 ──
    App-->>CL: 크래시 발생
    Note over CL: 다음 실행 시 자동 업로드
    Note over CL: archive 시 dSYM도 함께 업로드(Run Script)
```
