### PR TITLE
Firebase Analytics를 도입합니다.

### DIFF
--- a/Clients/AnalyticsClientLive/AnalyticsClient+Live.swift
+++ b/Clients/AnalyticsClientLive/AnalyticsClient+Live.swift
@@ -1,0 +1,72 @@
+import ComposableArchitecture
+import Domain
+import FirebaseAnalytics
+import Foundation
+
+extension AnalyticsClient: @retroactive DependencyKey {
+    public static let liveValue: AnalyticsClient = .init(
+        track: { event in
+            let (name, params) = mapEvent(event)
+            Analytics.logEvent(name, parameters: params)
+        },
+        trackScreen: { screen in
+            Analytics.logEvent(
+                AnalyticsEventScreenView,
+                parameters: [
+                    AnalyticsParameterScreenName: screen.rawValue,
+                    AnalyticsParameterScreenClass: screen.rawValue
+                ]
+            )
+        },
+        setUserID: { uid in
+            Analytics.setUserID(uid)
+        },
+        setUserProperty: { property in
+            let (name, value) = mapProperty(property)
+            Analytics.setUserProperty(value, forName: name)
+        }
+    )
+}
+
+extension DependencyValues {
+    public var analytics: AnalyticsClient {
+        get { self[AnalyticsClient.self] }
+        set { self[AnalyticsClient.self] = newValue }
+    }
+}
+
+private func mapEvent(_ event: AnalyticsEvent) -> (String, [String: Any]?) {
+    switch event {
+    case .cryAnalysisStarted:
+        ("cry_analysis_started", nil)
+    case let .cryAnalysisResultViewed(emotion):
+        ("cry_analysis_result_viewed", ["emotion": emotion.rawValue])
+    case let .careRecordSaved(category):
+        ("care_record_saved", ["category": category.rawValue])
+    case let .noteCreated(noteID):
+        ("note_created", ["note_id": noteID.uuidString])
+    case let .noteUpdated(noteID):
+        ("note_updated", ["note_id": noteID.uuidString])
+    case .caregiverInviteStarted:
+        ("caregiver_invite_started", nil)
+    case .caregiverInviteCompleted:
+        ("caregiver_invite_completed", nil)
+    case let .statisticViewed(period):
+        ("statistic_viewed", ["period": period.rawValue])
+    case .statisticPDFExported:
+        ("statistic_pdf_exported", nil)
+    }
+}
+
+private func mapProperty(_ property: UserProperty) -> (String, String?) {
+    switch property {
+    case let .babyCount(count):
+        ("baby_count", String(count))
+    case let .hasCaregiver(flag):
+        ("has_caregiver", flag ? "true" : "false")
+    case let .babyAgeMonthsBucket(bucket):
+        ("baby_age_months", bucket.rawValue)
+    case let .authProvider(provider):
+        ("auth_provider", provider.rawValue)
+    }
+}

--- a/Clients/AnalyticsClientLive/AnalyticsClient+Test.swift
+++ b/Clients/AnalyticsClientLive/AnalyticsClient+Test.swift
@@ -1,0 +1,13 @@
+import ComposableArchitecture
+import Domain
+
+extension AnalyticsClient: @retroactive TestDependencyKey {
+    public static let testValue: AnalyticsClient = .init(
+        track: { _ in },
+        trackScreen: { _ in },
+        setUserID: { _ in },
+        setUserProperty: { _ in }
+    )
+
+    public static let previewValue: AnalyticsClient = testValue
+}

--- a/Clients/Bootstrap.swift
+++ b/Clients/Bootstrap.swift
@@ -1,4 +1,5 @@
 import Domain
+@preconcurrency import FirebaseAnalytics
 @preconcurrency import FirebaseAuth
 import FirebaseCore
 @preconcurrency import FirebaseCrashlytics
@@ -27,6 +28,7 @@ public enum AppBootstrap {
 
         Auth.auth().addStateDidChangeListener { _, user in
             Crashlytics.crashlytics().setUserID(user?.uid ?? "")
+            Analytics.setUserID(user?.uid)
         }
 
         AppLogger.info("AppBootstrap configured")

--- a/Domain/Analytics/AnalyticsClient.swift
+++ b/Domain/Analytics/AnalyticsClient.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct AnalyticsClient: Sendable {
+    public var track: @Sendable (AnalyticsEvent) -> Void
+    public var trackScreen: @Sendable (ScreenName) -> Void
+    public var setUserID: @Sendable (String?) -> Void
+    public var setUserProperty: @Sendable (UserProperty) -> Void
+
+    public init(
+        track: @escaping @Sendable (AnalyticsEvent) -> Void,
+        trackScreen: @escaping @Sendable (ScreenName) -> Void,
+        setUserID: @escaping @Sendable (String?) -> Void,
+        setUserProperty: @escaping @Sendable (UserProperty) -> Void
+    ) {
+        self.track = track
+        self.trackScreen = trackScreen
+        self.setUserID = setUserID
+        self.setUserProperty = setUserProperty
+    }
+}

--- a/Domain/Analytics/AnalyticsEnums.swift
+++ b/Domain/Analytics/AnalyticsEnums.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum BabyAgeBucket: String, Sendable, Equatable {
+    case zeroToThree = "0-3"
+    case fourToSix = "4-6"
+    case sevenToTwelve = "7-12"
+    case thirteenToTwentyFour = "13-24"
+    case twentyFivePlus = "25+"
+
+    public init(monthsOld: Int) {
+        switch monthsOld {
+        case ..<4: self = .zeroToThree
+        case 4 ... 6: self = .fourToSix
+        case 7 ... 12: self = .sevenToTwelve
+        case 13 ... 24: self = .thirteenToTwentyFour
+        default: self = .twentyFivePlus
+        }
+    }
+}
+
+public enum AnalyticsAuthProvider: String, Sendable, Equatable {
+    case apple
+    case google
+    case unknown
+
+    public init(providerIDs: [String]) {
+        if providerIDs.contains("apple.com") {
+            self = .apple
+        } else if providerIDs.contains("google.com") {
+            self = .google
+        } else {
+            self = .unknown
+        }
+    }
+}
+
+public enum StatisticPeriod: String, Sendable, Equatable {
+    case day
+    case week
+    case month
+}

--- a/Domain/Analytics/AnalyticsEvent.swift
+++ b/Domain/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum AnalyticsEvent: Sendable, Equatable {
+    case cryAnalysisStarted
+    case cryAnalysisResultViewed(emotion: EmotionType)
+    case careRecordSaved(category: CareEvent.Category)
+    case noteCreated(noteID: UUID)
+    case noteUpdated(noteID: UUID)
+    case caregiverInviteStarted
+    case caregiverInviteCompleted
+    case statisticViewed(period: StatisticPeriod)
+    case statisticPDFExported
+}

--- a/Domain/Analytics/ScreenName.swift
+++ b/Domain/Analytics/ScreenName.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum ScreenName: String, Sendable, Equatable {
+    case home
+    case cryAnalysisHome = "cry_analysis_home"
+    case cryAnalysisRunning = "cry_analysis_running"
+    case cryAnalysisResult = "cry_analysis_result"
+    case noteList = "note_list"
+    case noteEditor = "note_editor"
+    case babyRegister = "baby_register"
+    case caregiverInvite = "caregiver_invite"
+    case statistic
+    case settings
+    case login
+}

--- a/Domain/Analytics/UserProperty.swift
+++ b/Domain/Analytics/UserProperty.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum UserProperty: Sendable, Equatable {
+    case babyCount(Int)
+    case hasCaregiver(Bool)
+    case babyAgeMonthsBucket(BabyAgeBucket)
+    case authProvider(AnalyticsAuthProvider)
+}

--- a/Features/BabyRegister/BabyRegisterFlowFeature.swift
+++ b/Features/BabyRegister/BabyRegisterFlowFeature.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Domain
 import Foundation
 
 @Reducer
@@ -13,6 +14,7 @@ public struct BabyRegisterFlowFeature {
 
     public enum Action {
         public enum ViewAction {
+            case task
             case cancelTapped
         }
 
@@ -28,6 +30,8 @@ public struct BabyRegisterFlowFeature {
         case path(StackActionOf<Path>)
     }
 
+    @Dependency(\.analytics) var analytics
+
     public init() {}
 
     public var body: some ReducerOf<Self> {
@@ -36,6 +40,9 @@ public struct BabyRegisterFlowFeature {
         }
         Reduce { state, action in
             switch action {
+            case .view(.task):
+                return .run { [analytics] _ in analytics.trackScreen(.babyRegister) }
+
             case .view(.cancelTapped):
                 return .send(.delegate(.cancelled))
 

--- a/Features/BabyRegister/BabyRegisterFlowView.swift
+++ b/Features/BabyRegister/BabyRegisterFlowView.swift
@@ -25,5 +25,6 @@ public struct BabyRegisterFlowView: View {
                 ExistingBabyRegisterView(store: existingStore)
             }
         }
+        .task { store.send(.view(.task)) }
     }
 }

--- a/Features/BabyRegister/Existing/ExistingBabyRegisterFeature.swift
+++ b/Features/BabyRegister/Existing/ExistingBabyRegisterFeature.swift
@@ -42,6 +42,7 @@ public struct ExistingBabyRegisterFeature {
         case alert(PresentationAction<Alert>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.babyClient) var babyClient
 
     public init() {}
@@ -61,7 +62,8 @@ public struct ExistingBabyRegisterFeature {
 
                 state.isSubmitting = true
 
-                return .run { [babyClient] send in
+                return .run { [analytics, babyClient] send in
+                    analytics.track(.caregiverInviteStarted)
                     do throws(BabyError) {
                         try await babyClient.registerExistingBaby(babyID)
                         await send(._internal(.submitSucceeded))
@@ -72,7 +74,10 @@ public struct ExistingBabyRegisterFeature {
 
             case ._internal(.submitSucceeded):
                 state.isSubmitting = false
-                return .send(.delegate(.completed))
+                return .merge(
+                    .run { [analytics] _ in analytics.track(.caregiverInviteCompleted) },
+                    .send(.delegate(.completed))
+                )
 
             case let ._internal(.submitFailed(error)):
                 state.isSubmitting = false

--- a/Features/CryAnalysis/Analysis/CryAnalysisFeature.swift
+++ b/Features/CryAnalysis/Analysis/CryAnalysisFeature.swift
@@ -37,6 +37,7 @@ public struct CryAnalysisFeature {
     }
 
     @Dependency(\.audioRecorderClient) var audioRecorderClient
+    @Dependency(\.analytics)           var analytics
     @Dependency(\.cryAnalysisClient)   var cryAnalysisClient
     @Dependency(\.cryRecordClient)     var cryRecordClient
     @Dependency(\.continuousClock)     var clock
@@ -56,24 +57,27 @@ public struct CryAnalysisFeature {
             case let .view(viewAction):
                 switch viewAction {
                 case .task:
-                    return .run { [audioRecorderClient, uuid] send in
-                        let url = FileManager.default.temporaryDirectory
-                            .appendingPathComponent(uuid().uuidString)
-                            .appendingPathExtension("caf")
-                        await withTaskCancellationHandler {
-                            do {
-                                try await audioRecorderClient.startRecording(url)
-                            } catch {
-                                await send(._internal(.recordingFailed))
+                    return .merge(
+                        .run { [analytics] _ in analytics.trackScreen(.cryAnalysisRunning) },
+                        .run { [audioRecorderClient, uuid] send in
+                            let url = FileManager.default.temporaryDirectory
+                                .appendingPathComponent(uuid().uuidString)
+                                .appendingPathExtension("caf")
+                            await withTaskCancellationHandler {
+                                do {
+                                    try await audioRecorderClient.startRecording(url)
+                                } catch {
+                                    await send(._internal(.recordingFailed))
+                                    try? FileManager.default.removeItem(at: url)
+                                    return
+                                }
+                                await send(._internal(.tickingStarted(url)))
+                            } onCancel: {
                                 try? FileManager.default.removeItem(at: url)
-                                return
                             }
-                            await send(._internal(.tickingStarted(url)))
-                        } onCancel: {
-                            try? FileManager.default.removeItem(at: url)
                         }
-                    }
-                    .cancellable(id: CancelID.lifecycle)
+                        .cancellable(id: CancelID.lifecycle)
+                    )
 
                 case .cancelTapped:
                     return .merge(
@@ -120,20 +124,23 @@ public struct CryAnalysisFeature {
                     .cancellable(id: CancelID.lifecycle)
 
                 case let .recordingFinished(url):
-                    return .run { [cryAnalysisClient] send in
-                        await withTaskCancellationHandler {
-                            do {
-                                let record = try await cryAnalysisClient.analyze(url)
-                                await send(._internal(.analysisSucceeded(record)))
-                            } catch {
-                                await send(._internal(.analysisFailed))
+                    return .merge(
+                        .run { [analytics] _ in analytics.track(.cryAnalysisStarted) },
+                        .run { [cryAnalysisClient] send in
+                            await withTaskCancellationHandler {
+                                do {
+                                    let record = try await cryAnalysisClient.analyze(url)
+                                    await send(._internal(.analysisSucceeded(record)))
+                                } catch {
+                                    await send(._internal(.analysisFailed))
+                                }
+                                try? FileManager.default.removeItem(at: url)
+                            } onCancel: {
+                                try? FileManager.default.removeItem(at: url)
                             }
-                            try? FileManager.default.removeItem(at: url)
-                        } onCancel: {
-                            try? FileManager.default.removeItem(at: url)
                         }
-                    }
-                    .cancellable(id: CancelID.lifecycle)
+                        .cancellable(id: CancelID.lifecycle)
+                    )
 
                 case .recordingFailed:
                     state.stage = .failure(.recordingFailed)
@@ -150,15 +157,22 @@ public struct CryAnalysisFeature {
 
                 case let .analysisSucceeded(record):
                     let scores = record.aggregatedScores
+                    let primary = scores.first ?? EmotionScore(emotion: .unknown, confidence: 0)
                     state.stage = .result(
                         ResultDisplay(
-                            primary: scores.first ?? EmotionScore(emotion: .unknown, confidence: 0),
+                            primary: primary,
                             others: Array(scores.dropFirst().prefix(3))
                         )
                     )
-                    return .run { [cryRecordClient, babyID = state.baby.id, record] _ in
-                        try? await cryRecordClient.addRecord(babyID, record)
-                    }
+                    return .merge(
+                        .run { [analytics, emotion = primary.emotion] _ in
+                            analytics.trackScreen(.cryAnalysisResult)
+                            analytics.track(.cryAnalysisResultViewed(emotion: emotion))
+                        },
+                        .run { [cryRecordClient, babyID = state.baby.id, record] _ in
+                            try? await cryRecordClient.addRecord(babyID, record)
+                        }
+                    )
                 }
             }
         }

--- a/Features/CryAnalysis/Home/CryAnalysisHomeFeature.swift
+++ b/Features/CryAnalysis/Home/CryAnalysisHomeFeature.swift
@@ -17,6 +17,7 @@ public struct CryAnalysisHomeFeature {
 
     public enum Action {
         public enum ViewAction {
+            case task
             case startTapped
             case recordsButtonTapped
         }
@@ -36,6 +37,7 @@ public struct CryAnalysisHomeFeature {
         case alert(PresentationAction<Alert>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.audioRecorderClient) var audioRecorderClient
     @Dependency(\.openURL) var openURL
 
@@ -44,6 +46,9 @@ public struct CryAnalysisHomeFeature {
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .view(.task):
+                return .run { [analytics] _ in analytics.trackScreen(.cryAnalysisHome) }
+
             case .view(.startTapped):
                 return .run { [audioRecorderClient] send in
                     let granted = await audioRecorderClient.requestPermission()

--- a/Features/CryAnalysis/Home/CryAnalysisHomeView.swift
+++ b/Features/CryAnalysis/Home/CryAnalysisHomeView.swift
@@ -22,6 +22,7 @@ public struct CryAnalysisHomeView: View {
             }
         }
         .alert($store.scope(state: \.alert, action: \.alert))
+        .task { store.send(.view(.task)) }
     }
 
     private var introContent: some View {

--- a/Features/Home/HomeFeature.swift
+++ b/Features/Home/HomeFeature.swift
@@ -60,6 +60,7 @@ public struct HomeFeature {
         case editRecord(PresentationAction<EditRecordFeature.Action>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.careRecordClient) var careRecordClient
 
     public init() {}
@@ -68,7 +69,13 @@ public struct HomeFeature {
         BindingReducer()
         Reduce { state, action in
             switch action {
-            case .view(.task), .binding(\.selectedDate):
+            case .view(.task):
+                return .merge(
+                    loadRecords(for: state),
+                    .run { [analytics] _ in analytics.trackScreen(.home) }
+                )
+
+            case .binding(\.selectedDate):
                 return loadRecords(for: state)
 
             case let .view(.careEntryTapped(entry)):
@@ -140,7 +147,7 @@ public struct HomeFeature {
             of: state.selectedDate
         ) ?? now
 
-        return .run { [careRecordClient] send in
+        return .run { [analytics, careRecordClient] send in
             do throws(CareRecordError) {
                 let event: CareEvent? = switch entry {
                 case .feeding:
@@ -171,6 +178,7 @@ public struct HomeFeature {
                 guard let event else { return }
 
                 try await careRecordClient.addRecord(babyID, CareRecord(createdAt: createdAt, event: event))
+                analytics.track(.careRecordSaved(category: event.category))
                 await send(._internal(.recordAdded))
             } catch {
                 await send(._internal(.recordAddFailed(error)))

--- a/Features/Login/LoginFeature.swift
+++ b/Features/Login/LoginFeature.swift
@@ -15,6 +15,7 @@ public struct LoginFeature {
 
     public enum Action {
         public enum ViewAction {
+            case task
             case signInWithAppleTapped
             case signInWithGoogleTapped
         }
@@ -32,6 +33,7 @@ public struct LoginFeature {
         case alert(PresentationAction<Alert>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.authClient) var authClient
 
     public init() {}
@@ -39,6 +41,9 @@ public struct LoginFeature {
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .view(.task):
+                return .run { [analytics] _ in analytics.trackScreen(.login) }
+
             case .view(.signInWithAppleTapped):
                 state.isLoading = true
                 return .run { [authClient] send in

--- a/Features/Login/LoginView.swift
+++ b/Features/Login/LoginView.swift
@@ -39,5 +39,6 @@ public struct LoginView: View {
         .background(Color.Semantic.launchBackground.ignoresSafeArea())
         .loadingOverlay(isPresented: store.isLoading)
         .alert($store.scope(state: \.alert, action: \.alert))
+        .task { store.send(.view(.task)) }
     }
 }

--- a/Features/MainTab/MainTabFeature.swift
+++ b/Features/MainTab/MainTabFeature.swift
@@ -67,6 +67,7 @@ public struct MainTabFeature {
         case notificationSync(NotificationSyncFeature.Action)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.babyClient) var babyClient
     @Dependency(\.caregiverClient) var caregiverClient
 
@@ -84,6 +85,29 @@ public struct MainTabFeature {
         state.note.baby = baby
         state.cryAnalysis.baby = baby
         state.statistic.baby = baby
+    }
+
+    private func emitUserProperties(state: State) -> Effect<Action> {
+        let babyCount = state.babies.count
+        let hasCaregiver = (state.babies.first?.caregiverIDs.count ?? 0) > 1
+        let bucket: BabyAgeBucket = {
+            guard let baby = state.babies.first else { return .zeroToThree }
+
+            let months = Calendar.current.dateComponents(
+                [.month],
+                from: baby.birthDate,
+                to: Date()
+            ).month ?? 0
+            return BabyAgeBucket(monthsOld: months)
+        }()
+        let provider = AnalyticsAuthProvider(providerIDs: state.session.providerIDs)
+
+        return .run { [analytics] _ in
+            analytics.setUserProperty(.babyCount(babyCount))
+            analytics.setUserProperty(.hasCaregiver(hasCaregiver))
+            analytics.setUserProperty(.babyAgeMonthsBucket(bucket))
+            analytics.setUserProperty(.authProvider(provider))
+        }
     }
 
     public var body: some ReducerOf<Self> {
@@ -126,6 +150,7 @@ public struct MainTabFeature {
             case .view(.task):
                 return .merge(
                     .send(.notificationSync(.view(.task))),
+                    emitUserProperties(state: state),
                     .run { [babyClient] send in
                         for await babies in babyClient.streamBabies() {
                             await send(._internal(.babiesLoaded(babies)))
@@ -145,7 +170,7 @@ public struct MainTabFeature {
                 state.settings.babies = state.babies
                 state.home.babies = state.babies
                 propagateSelectedBaby(into: &state)
-                return .none
+                return emitUserProperties(state: state)
 
             case let ._internal(.caregiverLoaded(caregiver)):
                 guard let caregiver else { return .none }

--- a/Features/Note/Diary/DiaryEditorFeature.swift
+++ b/Features/Note/Diary/DiaryEditorFeature.swift
@@ -47,6 +47,7 @@ public struct DiaryEditorFeature {
 
     public enum Action: BindableAction {
         public enum ViewAction: Equatable {
+            case task
             case removePhotoButtonTapped(DiaryPhoto.ID)
             case cancelButtonTapped
             case saveButtonTapped
@@ -71,6 +72,7 @@ public struct DiaryEditorFeature {
         case binding(BindingAction<State>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.noteClient) var noteClient
     @Dependency(\.storageClient) var storageClient
     @Dependency(\.authClient) var authClient
@@ -114,6 +116,9 @@ public struct DiaryEditorFeature {
                 state.photos.append(photo)
                 return .none
 
+            case .view(.task):
+                return .run { [analytics] _ in analytics.trackScreen(.noteEditor) }
+
             case let .view(.removePhotoButtonTapped(id)):
                 state.photos.removeAll { $0.id == id }
                 state.pickerItems.removeAll { $0.itemIdentifier == id }
@@ -138,7 +143,7 @@ public struct DiaryEditorFeature {
                 let date = state.date
                 let photoDatas = state.photos.map(\.data)
                 AppLogger.info("save start noteID=\(noteID) creatorID=\(creatorID) photos=\(photoDatas.count)")
-                return .run { [storageClient, noteClient, babyID = state.babyID] send in
+                return .run { [analytics, storageClient, noteClient, babyID = state.babyID] send in
                     let imageURLs: [URL]
                     do throws(StorageError) {
                         imageURLs = try await uploadDiaryPhotos(
@@ -178,6 +183,7 @@ public struct DiaryEditorFeature {
                         return
                     }
                     AppLogger.info("save completed noteID=\(noteID)")
+                    analytics.track(.noteCreated(noteID: noteID))
                     await send(._internal(.saveCompleted))
                 }
 

--- a/Features/Note/Diary/DiaryEditorView.swift
+++ b/Features/Note/Diary/DiaryEditorView.swift
@@ -36,6 +36,7 @@ public struct DiaryEditorView: View {
                         .disabled(!store.canSave)
                 }
             }
+            .task { store.send(.view(.task)) }
         }
     }
 

--- a/Features/Note/Home/NoteHomeFeature.swift
+++ b/Features/Note/Home/NoteHomeFeature.swift
@@ -63,6 +63,7 @@ public struct NoteHomeFeature {
 
     private enum CancelID { case notesStream }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.noteClient) var noteClient
 
     public init() {}
@@ -71,7 +72,13 @@ public struct NoteHomeFeature {
         BindingReducer()
         Reduce { state, action in
             switch action {
-            case .view(.task), .binding(\.month):
+            case .view(.task):
+                return .merge(
+                    streamEffect(state: state),
+                    .run { [analytics] _ in analytics.trackScreen(.noteList) }
+                )
+
+            case .binding(\.month):
                 return streamEffect(state: state)
 
             case .view(.diaryButtonTapped):

--- a/Features/Note/Schedule/ScheduleEditorFeature.swift
+++ b/Features/Note/Schedule/ScheduleEditorFeature.swift
@@ -73,6 +73,7 @@ public struct ScheduleEditorFeature {
         case alert(PresentationAction<Alert>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.noteClient) var noteClient
     @Dependency(\.localNotificationClient) var localNotificationClient
     @Dependency(\.openURL) var openURL
@@ -153,13 +154,14 @@ public struct ScheduleEditorFeature {
                     date: state.date,
                     reminder: reminder
                 )
-                return .run { [noteClient, babyID = state.babyID] send in
+                return .run { [analytics, noteClient, babyID = state.babyID] send in
                     do throws(NoteError) {
                         try await noteClient.addNote(babyID, note)
                     } catch {
                         await send(._internal(.saveFailed(error)))
                         return
                     }
+                    analytics.track(.noteCreated(noteID: note.id))
                     await send(._internal(.saveCompleted))
                 }
 

--- a/Features/Settings/Caregivers/CaregiverListFeature.swift
+++ b/Features/Settings/Caregivers/CaregiverListFeature.swift
@@ -43,6 +43,7 @@ public struct CaregiverListFeature {
         case alert(PresentationAction<Alert>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.caregiverClient) var caregiverClient
     @Dependency(\.babyClient) var babyClient
 
@@ -56,12 +57,15 @@ public struct CaregiverListFeature {
             switch action {
             case .view(.task):
                 let ids = state.baby.caregiverIDs
-                return .run { [caregiverClient] send in
-                    for await caregivers in caregiverClient.streamCaregivers(ids) {
-                        await send(._internal(.caregiversLoaded(caregivers)))
+                return .merge(
+                    .run { [caregiverClient] send in
+                        for await caregivers in caregiverClient.streamCaregivers(ids) {
+                            await send(._internal(.caregiversLoaded(caregivers)))
+                        }
                     }
-                }
-                .cancellable(id: CancelID.stream, cancelInFlight: true)
+                    .cancellable(id: CancelID.stream, cancelInFlight: true),
+                    .run { [analytics] _ in analytics.trackScreen(.caregiverInvite) }
+                )
 
             case let .view(.removeTapped(id)):
                 guard state.isMainCaregiver,

--- a/Features/Settings/SettingsFeature.swift
+++ b/Features/Settings/SettingsFeature.swift
@@ -41,6 +41,7 @@ public struct SettingsFeature {
 
     public enum Action: BindableAction {
         public enum ViewAction {
+            case task
             case signOutTapped
             case deleteAccountTapped
             case signOutConfirmed
@@ -69,6 +70,7 @@ public struct SettingsFeature {
         case path(StackActionOf<Path>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.authClient) var authClient
 
     public init() {}
@@ -79,6 +81,9 @@ public struct SettingsFeature {
             switch action {
             case .binding:
                 return .none
+
+            case .view(.task):
+                return .run { [analytics] _ in analytics.trackScreen(.settings) }
 
             case .view(.signOutTapped):
                 state.alert = AlertState {

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -50,6 +50,7 @@ public struct SettingsView: View {
                 CaregiverListView(store: store)
             }
         }
+        .task { store.send(.view(.task)) }
     }
 }
 

--- a/Features/Statistic/StatisticFeature.swift
+++ b/Features/Statistic/StatisticFeature.swift
@@ -95,6 +95,7 @@ public struct StatisticFeature {
         case pdfPreview(PresentationAction<PDFPreviewFeature.Action>)
     }
 
+    @Dependency(\.analytics) var analytics
     @Dependency(\.careRecordClient) var careRecordClient
 
     public init() {}
@@ -104,12 +105,24 @@ public struct StatisticFeature {
         Reduce { state, action in
             switch action {
             case .view(.task):
+                let currentPeriod = period(for: state.mode)
                 return .merge(
                     loadRecords(for: state),
-                    loadGrowthRecords(for: state)
+                    loadGrowthRecords(for: state),
+                    .run { [analytics] _ in
+                        analytics.trackScreen(.statistic)
+                        analytics.track(.statisticViewed(period: currentPeriod))
+                    }
                 )
 
-            case .binding(\.mode), .binding(\.selectedDate):
+            case .binding(\.mode):
+                let currentPeriod = period(for: state.mode)
+                return .merge(
+                    loadRecords(for: state),
+                    .run { [analytics] _ in analytics.track(.statisticViewed(period: currentPeriod)) }
+                )
+
+            case .binding(\.selectedDate):
                 return loadRecords(for: state)
 
             case let ._internal(.recordsLoaded(records)):
@@ -137,7 +150,7 @@ public struct StatisticFeature {
                     records: state.records,
                     date: state.selectedDate
                 )
-                return .none
+                return .run { [analytics] _ in analytics.track(.statisticPDFExported) }
 
             case .pdfPreview:
                 return .none
@@ -152,6 +165,13 @@ public struct StatisticFeature {
         .forEach(\.path, action: \.path)
         .ifLet(\.$pdfPreview, action: \.pdfPreview) {
             PDFPreviewFeature()
+        }
+    }
+
+    private func period(for mode: Mode) -> StatisticPeriod {
+        switch mode {
+        case .daily: .day
+        case .weekly: .week
         }
     }
 

--- a/Project.swift
+++ b/Project.swift
@@ -113,7 +113,9 @@ let project = Project(
             scripts: [
                 .post(
                     script: """
-                    "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+                    SCRIPT="${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+                    [ -f "$SCRIPT" ] || SCRIPT="${SRCROOT}/Tuist/.build/checkouts/firebase-ios-sdk/Crashlytics/run"
+                    "$SCRIPT"
                     """,
                     name: "Firebase Crashlytics dSYM Upload",
                     inputPaths: [

--- a/Project.swift
+++ b/Project.swift
@@ -50,6 +50,7 @@ let project = Project(
                 .external(name: "FirebaseStorage"),
                 .external(name: "FirebaseMessaging"),
                 .external(name: "FirebaseCrashlytics"),
+                .external(name: "FirebaseAnalytics"),
                 .external(name: "GoogleSignIn"),
                 .external(name: "GoogleSignInSwift")
             ]
@@ -163,6 +164,28 @@ let project = Project(
             dependencies: [
                 .target(name: "MyI")
             ]
+        )
+    ],
+    schemes: [
+        .scheme(
+            name: "MyI",
+            shared: true,
+            buildAction: .buildAction(targets: ["MyI"]),
+            testAction: .targets(
+                ["FeaturesTests", "MyITests"],
+                configuration: "Debug"
+            ),
+            runAction: .runAction(
+                configuration: "Debug",
+                arguments: .arguments(
+                    launchArguments: [
+                        .launchArgument(name: "-FIRDebugEnabled", isEnabled: true)
+                    ]
+                )
+            ),
+            archiveAction: .archiveAction(configuration: "Release"),
+            profileAction: .profileAction(configuration: "Release"),
+            analyzeAction: .analyzeAction(configuration: "Debug")
         )
     ]
 )


### PR DESCRIPTION
## 📝 개요

Firebase Analytics SDK를 도입해 화면 진입(screen_view)과 핵심 사용자 행동을 이벤트로 수집합니다. 
PII는 enum 타입 단계에서 차단하고, Debug 빌드는 운영 콘솔 대신 DebugView로만 송신합니다.

## 🔗 관련 이슈

- Refs #218

## 📖 설명

### 강타입 이벤트로 PII 원천 차단

`AnalyticsEvent` enum의 associated value를 `UUID` · `Int` · Domain enum(`EmotionType`, `CareEvent.Category`, `StatisticPeriod`)로만 한정합니다. 
이름·생일·위치 같은 자유 문자열이 시그니처에 들어갈 자리 자체가 없어 호출부 실수가 컴파일 단계에서 막힙니다.
 Firebase로의 매핑은 `AnalyticsClientLive`의 `mapEvent`/`mapProperty` 단일 함수 두 곳에 격리해, PII 정책의 사고 지점이 한 곳으로 모입니다.

User Property도 동일 원칙: `babyCount(Int)`, `hasCaregiver(Bool)`, `babyAgeMonthsBucket(BabyAgeBucket)`, `authProvider(AnalyticsAuthProvider)`

### 화면 트래킹 = TCA Reducer `.task`에서

SwiftUI는 hosting controller 하나라 Firebase 자동 screen_view가 작동하지 않습니다. View modifier 방식보다는 reducer가 화면명을 소유하는 쪽이 컨벤션 강제 · 테스트성에서 유리하다고 판단해, 각 Feature `.task` action에서 `analytics.trackScreen(.<name>)`을 emit합니다.
 `task` action이 없던 5개 Feature는 ViewAction enum에 `task` case 신설 + View 끝에 `.task { store.send(.view(.task)) }` 1줄 추가로 통일성 유지.

### User Property는 진입 reducer에서

`AppBootstrap`의 Auth state listener는 `setUserID`만 처리합니다.
User Property는 `BabyClient`/`CaregiverClient` 데이터 의존이라 listener의 nonisolated closure에서 다루기 어색하고, 진입 reducer인 `MainTabFeature`가 이미 `babies` · `caregiver` · `session`을 모두 보유하고 있어 자연스러운 위치입니다.
`.task` 진입 시점과 `_internal(.babiesLoaded)` 후에 `setUserProperty` 4종을 일괄 호출.

### Debug 빌드 = collection ON + DebugView 자동

Crashlytics와 다른 정책입니다(Crashlytics는 Debug 수집 OFF). Analytics는 DebugView로 개발 중 이벤트를 실시간 검증하는 것이 도입 가치의 큰 부분이라, scheme launchArguments에 `-FIRDebugEnabled`을 hard-set해 **Debug 빌드는 항상 DebugView로만** 송신되도록 했습니다. 운영 Console 데이터엔 영향 0.

## 🔄 플로우 다이어그램

```mermaid
sequenceDiagram
    participant App as AppDelegate
    participant Boot as AppBootstrap
    participant Auth as FirebaseAuth
    participant Tab as MainTabFeature
    participant Feat as Feature.task
    participant CL as Crashlytics
    participant AN as Analytics

    App->>Boot: configure()
    Boot->>Auth: addStateDidChangeListener
    Note over Auth: 로그인/로그아웃/세션 복원
    Auth-->>CL: setUserID(uid ?? "")
    Auth-->>AN: setUserID(uid)

    App->>Tab: 진입 (.task)
    Tab->>Tab: BabyClient/CaregiverClient stream
    Tab-->>AN: setUserProperty × 4

    App->>Feat: 화면 진입 (.task)
    Feat-->>AN: trackScreen(.<name>)
    Note over AN: Debug = DebugView 송신<br/>Release = 운영 Console 송신

    App->>Feat: 사용자 행동
    Feat-->>AN: track(.<event>)
```
