### PR TITLE
fix(app): 가로모드 회전 차단

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -92,6 +92,7 @@ let project = Project(
                 "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
                 "UILaunchStoryboardName": "LaunchScreen",
                 "ITSAppUsesNonExemptEncryption": false,
+                "UISupportedInterfaceOrientations": ["UIInterfaceOrientationPortrait"],
                 "NSMicrophoneUsageDescription": "아기의 울음소리를 분석하기 위해 마이크 권한이 필요합니다.",
                 "UIBackgroundModes": ["remote-notification"],
                 "CFBundleURLTypes": [


### PR DESCRIPTION
## 📝 개요

앱에 화면 방향 제한이 없어 기기를 가로로 돌리면 화면이 같이 회전되던 문제 수정. 세로 기준으로 디자인된 UI가 가로에서 깨지는 것을 방지하기 위해 Portrait 단일 방향으로 고정.

## 🔗 관련 이슈

- Closes #221

## 🛠️ 작업 내용

- `Project.swift` infoPlist에 `UISupportedInterfaceOrientations: ["UIInterfaceOrientationPortrait"]` 추가
- `tuist generate`로 Xcode 프로젝트 재생성 후 빌드 검증

## 📖 설명

iOS는 `UISupportedInterfaceOrientations` 키가 없으면 기본값(iPhone 기준 Portrait + LandscapeLeft + LandscapeRight)을 적용함. 이번 변경으로 해당 키를 Portrait 단일 항목으로 명시하여 시스템 회전 이벤트가 발생해도 root window가 가로로 전환되지 않도록 함. SwiftUI/TCA 화면 코드 변경 없이 앱 진입점 단일 설정으로 전체 화면에 일괄 적용됨.

## 🔄 플로우 다이어그램

config-only 변경이라 별도 흐름 없음.

```mermaid
flowchart LR
    Device[기기 회전 이벤트] --> iOS[iOS Window]
    iOS -->|UISupportedInterfaceOrientations<br/>= Portrait| Locked[세로 유지]
```