### PR TITLE
fix(cry-analysis): 분석 화면 종료 시 탭바 등장 지연 수정

### DIFF
--- a/Features/CryAnalysis/Analysis/CryAnalysisView.swift
+++ b/Features/CryAnalysis/Analysis/CryAnalysisView.swift
@@ -36,6 +36,5 @@ public struct CryAnalysisView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.Semantic.screenBackground.ignoresSafeArea())
         .task { await store.send(.view(.task)).finish() }
-        .toolbar(.hidden, for: .navigationBar, .tabBar)
     }
 }

--- a/Features/CryAnalysis/Home/CryAnalysisHomeFeature.swift
+++ b/Features/CryAnalysis/Home/CryAnalysisHomeFeature.swift
@@ -9,6 +9,7 @@ public struct CryAnalysisHomeFeature {
         public var baby: Baby
         public var path = StackState<Path.State>()
         @Presents public var alert: AlertState<Action.Alert>?
+        @Presents public var analysis: CryAnalysisFeature.State?
 
         public init(baby: Baby) {
             self.baby = baby
@@ -35,6 +36,7 @@ public struct CryAnalysisHomeFeature {
 
         case path(StackAction<Path.State, Path.Action>)
         case alert(PresentationAction<Alert>)
+        case analysis(PresentationAction<CryAnalysisFeature.Action>)
     }
 
     @Dependency(\.analytics) var analytics
@@ -60,7 +62,7 @@ public struct CryAnalysisHomeFeature {
                 return .none
 
             case ._internal(.permissionResolved(true)):
-                state.path.append(.analysis(CryAnalysisFeature.State(baby: state.baby)))
+                state.analysis = CryAnalysisFeature.State(baby: state.baby)
                 return .none
 
             case ._internal(.permissionResolved(false)):
@@ -85,11 +87,14 @@ public struct CryAnalysisHomeFeature {
                     _ = await openURL(url)
                 }
 
-            case .alert, .path:
+            case .alert, .analysis, .path:
                 return .none
             }
         }
         .ifLet(\.$alert, action: \.alert)
+        .ifLet(\.$analysis, action: \.analysis) {
+            CryAnalysisFeature()
+        }
         .forEach(\.path, action: \.path)
     }
 }
@@ -97,7 +102,6 @@ public struct CryAnalysisHomeFeature {
 extension CryAnalysisHomeFeature {
     @Reducer
     public enum Path {
-        case analysis(CryAnalysisFeature)
         case recordList(CryRecordListFeature)
     }
 }

--- a/Features/CryAnalysis/Home/CryAnalysisHomeView.swift
+++ b/Features/CryAnalysis/Home/CryAnalysisHomeView.swift
@@ -15,13 +15,14 @@ public struct CryAnalysisHomeView: View {
             introContent
         } destination: { childStore in
             switch childStore.case {
-            case let .analysis(store):
-                CryAnalysisView(store: store)
             case let .recordList(store):
                 CryRecordListView(store: store)
             }
         }
         .alert($store.scope(state: \.alert, action: \.alert))
+        .fullScreenCover(item: $store.scope(state: \.analysis, action: \.analysis)) { analysisStore in
+            CryAnalysisView(store: analysisStore)
+        }
         .task { store.send(.view(.task)) }
     }
 


### PR DESCRIPTION
## 📝 개요

울음 분석을 마치고 인트로 화면으로 돌아올 때 하단 탭바가 늦게 / 뚝 나타나던 문제 수정. `CryAnalysisView`의 표시 방식을 NavigationStack push 에서 `fullScreenCover` 로 전환해 탭바 visibility 전환 자체를 제거.

## 🔗 관련 이슈

- Closes #224

## 🛠️ 작업 내용

- `CryAnalysisHomeFeature.Path` 에서 `analysis` 케이스 제거, `@Presents var analysis: CryAnalysisFeature.State?` 로 이동
- `CryAnalysisHomeView` 에서 push 대신 `.fullScreenCover(item:)` 로 분석 화면 표시
- 더 이상 필요 없는 `CryAnalysisView` 의 `.toolbar(.hidden, for: .navigationBar, .tabBar)` 제거

## 📖 설명

SwiftUI `NavigationStack` 안에서 `.toolbar(.hidden, for: .tabBar)` 를 push 시점에 거는 구조는, pop 애니메이션과 탭바 visibility 전환이 별도 타이밍으로 동작해 탭바가 뒤늦게 페이드인되는 알려진 이슈가 있음. 분석 화면은 녹음/결과/실패 단계의 모달성 플로우이므로 push 대신 `fullScreenCover` 가 더 적합. 커버가 탭바를 그대로 덮고 dismiss 시 함께 사라지므로 탭바 전환 자체가 일어나지 않음.

내부적으로 `CryAnalysisFeature` 의 `@Dependency(\.dismiss)` 는 `@Presents` 와도 동일하게 동작하므로 inner reducer 는 손대지 않음. `Path` 는 `recordList` 단일 케이스만 남음.
바 위를 덮음.-> TabBar[(MainTab tabBar)]